### PR TITLE
ajout de l'option client.backoff dans les possibilités de config

### DIFF
--- a/src/M6Web/Bundle/AwsBundle/Resources/config/services.yml
+++ b/src/M6Web/Bundle/AwsBundle/Resources/config/services.yml
@@ -14,7 +14,7 @@ parameters:
     m6web_aws.client_factory.class: M6Web\Bundle\AwsBundle\Aws\ClientFactory
     m6web_aws.client_factory.name: "m6web_aws.client_factory"
     m6web_aws.aws_factory.class: Aws\Common\Aws
-    m6web_aws.alias_keys: ['signature_service', 'signature_region', 'curl_options', 'request_options', 'command_params']
+    m6web_aws.alias_keys: ['signature_service', 'signature_region', 'curl_options', 'request_options', 'command_params', 'client_backoff']
 
 services:
     m6web_aws.client_factory:


### PR DESCRIPTION
ajout de l'option client.backoff

a mettre à false pour désactiver le retry
