### PR TITLE
Add a notice to deprecate the bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 #### Aws client as a Symfony Service
 
+# /!\ This bundle is deprecated
 
+Please use the official [AWS Symfony bundle](https://github.com/aws/aws-sdk-php-symfony) instead.
 
 ### configure your AWS user credentials and services
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 #### Aws client as a Symfony Service
 
-# /!\ This bundle is deprecated
+# ⚠ This bundle is deprecated
 
 Please use the official [AWS Symfony bundle](https://github.com/aws/aws-sdk-php-symfony) instead.
 


### PR DESCRIPTION
This bundle uses an outdated version of the aws-sdk-php package (v2). We can't migrate to the latest version of aws-sdk-php without BC. That's why we advise you to migrate to the official [AWS Symfony bundle](https://github.com/aws/aws-sdk-php-symfony) if you want to use the latest version of the AWS SDK.